### PR TITLE
Languages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,3 +72,11 @@ Style/StringChars: # (new in 1.12)
   Enabled: true
 Style/SwapValues: # (new in 1.1)
   Enabled: true
+Lint/EmptyInPattern: # (new in 1.16)
+  Enabled: true
+Style/InPatternThen: # (new in 1.16)
+  Enabled: true
+Style/MultilineInPatternThen: # (new in 1.16)
+  Enabled: true
+Style/QuotedSymbols: # (new in 1.16)
+  Enabled: true

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ status.daily_limit      # => 50_000 or nil for no limit
 status.remaining_today  # => 45_500 or Float::INFINITY for unlimited
 ```
 
+### Language list
+
+You can fetch the list of supported languages:
+
+```ruby
+languages = Linguin.languages
+# => { de: ["German", "Deutsch"], ... }
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/linguin.rb
+++ b/lib/linguin.rb
@@ -27,6 +27,9 @@ require_relative "linguin/languages"
 # * number of requests today
 # * daily detection limit of your account (false for unlimited)
 # * remaining detections today (can be Infinity)
+#
+# = Linguin.languages
+# Returns the list of supported languages.
 module Linguin
   class << self
     def api_key=(api_key)

--- a/lib/linguin.rb
+++ b/lib/linguin.rb
@@ -7,6 +7,7 @@ require_relative "linguin/base_response"
 require_relative "linguin/detection"
 require_relative "linguin/bulk_detection"
 require_relative "linguin/status"
+require_relative "linguin/languages"
 
 # == Linguin API wrapper module
 # Can be used as a singleton to access all API methods.
@@ -42,6 +43,10 @@ module Linguin
 
     def status
       default_client.status
+    end
+
+    def languages
+      default_client.languages
     end
 
     private

--- a/lib/linguin/client.rb
+++ b/lib/linguin/client.rb
@@ -62,6 +62,12 @@ module Linguin
       Status.from_httparty(response: httparty_response)
     end
 
+    def languages
+      ensure_api_key!
+      httparty_response = self.class.get("/languages", headers: headers)
+      Languages.from_httparty(response: httparty_response)
+    end
+
     private
 
     def configure_api_key(key)

--- a/lib/linguin/client.rb
+++ b/lib/linguin/client.rb
@@ -63,8 +63,7 @@ module Linguin
     end
 
     def languages
-      ensure_api_key!
-      httparty_response = self.class.get("/languages", headers: headers)
+      httparty_response = self.class.get("/languages")
       Languages.from_httparty(response: httparty_response)
     end
 

--- a/lib/linguin/languages.rb
+++ b/lib/linguin/languages.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Linguin
+  # == Linguin::Status
+  # Returned by Linguin#status.
+  #
+  # [:+detections_today+:] how many detections you performed today
+  # [:+daily_limit+:] your daily detection limit (or false)
+  # [:+remaining_today+:] detections remaining today (can be Float::INFINITY)
+  class Languages < BaseResponse
+    class << self
+      def error(code, message)
+        new do |status|
+          status.error = {
+            code: code,
+            message: message
+          }
+        end.raise_on_error!
+      end
+
+      def success(response)
+        response
+      end
+    end
+  end
+end

--- a/lib/linguin/languages.rb
+++ b/lib/linguin/languages.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
 module Linguin
-  # == Linguin::Status
-  # Returned by Linguin#status.
-  #
-  # [:+detections_today+:] how many detections you performed today
-  # [:+daily_limit+:] your daily detection limit (or false)
-  # [:+remaining_today+:] detections remaining today (can be Float::INFINITY)
+  # == Linguin::Languages
+  # Returns a hash of supported languages.
   class Languages < BaseResponse
     class << self
       def error(code, message)

--- a/test/linguin_client_languages_test.rb
+++ b/test/linguin_client_languages_test.rb
@@ -14,7 +14,7 @@ class LinguinLanguagesTest < Minitest::Test
   end
 
   def test_that_languages_works
-    stub_with_json({ en: ["English", "English"], de: ["German", "Deutsch"], ar: ["Arabic", "العربية"] })
+    stub_with_json({ en: %w[English English], de: %w[German Deutsch], ar: %w[Arabic العربية] })
     client = Linguin::Client.new("abc")
     response = client.languages
     assert_equal "English", response[:en][0]

--- a/test/linguin_client_languages_test.rb
+++ b/test/linguin_client_languages_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LinguinLanguagesTest < Minitest::Test
+  def stub_with_json(mock_response)
+    json_response = JSON.generate(mock_response)
+    stub_request(:get, "https://api.linguin.ai/v1/languages")
+      .to_return(
+        status: 200,
+        body: json_response,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def test_that_languages_works
+    stub_with_json({ en: ["English", "English"], de: ["German", "Deutsch"], ar: ["Arabic", "العربية"] })
+    client = Linguin::Client.new("abc")
+    response = client.languages
+    assert_equal "English", response[:en][0]
+    assert_equal "Deutsch", response[:de][1]
+    assert_equal "العربية", response[:ar][1]
+  end
+end

--- a/test/linguin_test.rb
+++ b/test/linguin_test.rb
@@ -19,10 +19,12 @@ class LinguinTest < Minitest::Test
     client.expect :detect, true, ["test"]
     client.expect :detect!, true, ["test"]
     client.expect :status, true
+    client.expect :languages, true
     Linguin.stub :default_client, client do
       assert Linguin.detect("test")
       assert Linguin.detect!("test")
       assert Linguin.status
+      assert Linguin.languages
     end
     client.verify
   end


### PR DESCRIPTION
Adds support for the /languages endpoints returning the list of supported languages each with their name in English as well as their own language.